### PR TITLE
Fix/solve issues ivan

### DIFF
--- a/GEM/Data/pathway_description.txt
+++ b/GEM/Data/pathway_description.txt
@@ -1,5 +1,5 @@
 rxnID	rxnNames	KEGG_id	rxnFormula	grRules	Ecnumbers	KEGG_formula
-new_r_0001	poly(ethylene terephthalate) hydrolase	R11540	(ethylene terephthalate)n[e] + H2O[e] => (ethylene terephthalate)n-1[e] + 4-[(2-hydroxyethoxy)-carbonyl]benzoate[e]	ISF6_4831	EC3.1.1.101	C21451(n) + C00001 <=> C21451(n-1) + C21450
+new_r_0001	poly(ethylene terephthalate) hydrolase	R11540	(ethylene terephthalate)n[e] + H2O[e] => (ethylene terephthalate)n-1[e] + 4-[(2-hydroxyethoxy)-carbonyl]benzoate[e]	ISF6_4831	EC3.1.1.101	C21451 + C00001 <=> C21451 + C21450
 new_r_0002	mono(ethylene terephthalate) hydrolase	R11541	4-[(2-hydroxyethoxy)carbonyl]benzoate[e] + H2O[e] => terephthalate[e] + ethylene glycol[e]	ISF6_0224	EC3.1.1.102	C21450 + C00001 <=> C06337 + C01380
 new_r_0003	"L-1,2-propanediol oxidoreductase"	R01781	ethylene glycol[c] + NAD+[c] <=> glycolaldehyde[c] + NADH[c] + H+[c]	b2799	EC1.1.1.77	C01380 + C00003 <=> C00266 + C00004 + C00080
 new_r_0004	alkan-1-ol dehydrogenase (acceptor)	R00639	Primary alcohol + NAD+ <=> Aldehyde + NADH	pegdh	EC1.1.99.20	C00226 + C00028 <=> C00071 + C00030

--- a/GEM/Data/pathway_description.txt
+++ b/GEM/Data/pathway_description.txt
@@ -1,0 +1,10 @@
+rxnID	rxnNames	KEGG_id	rxnFormula	grRules	Ecnumbers	KEGG_formula
+new_r_0001	poly(ethylene terephthalate) hydrolase	R11540	(ethylene terephthalate)n[e] + H2O[e] => (ethylene terephthalate)n-1[e] + 4-[(2-hydroxyethoxy)-carbonyl]benzoate[e]	ISF6_4831	EC3.1.1.101	C21451(n) + C00001 <=> C21451(n-1) + C21450
+new_r_0002	mono(ethylene terephthalate) hydrolase	R11541	4-[(2-hydroxyethoxy)carbonyl]benzoate[e] + H2O[e] => terephthalate[e] + ethylene glycol[e]	ISF6_0224	EC3.1.1.102	C21450 + C00001 <=> C06337 + C01380
+new_r_0003	"L-1,2-propanediol oxidoreductase"	R01781	ethylene glycol[c] + NAD+[c] <=> glycolaldehyde[c] + NADH[c] + H+[c]	b2799	EC1.1.1.77	C01380 + C00003 <=> C00266 + C00004 + C00080
+new_r_0004	alkan-1-ol dehydrogenase (acceptor)	R00639	Primary alcohol + NAD+ <=> Aldehyde + NADH	pegdh	EC1.1.99.20	C00226 + C00028 <=> C00071 + C00030
+new_r_0005	polyurethanaseA		polyurethane[e] + H2O[e] => ehylene glycol[e] + ammonia[e] + polymethylene polyphenyl isocyanate[e]	pueA	EC3.1.1.3	C19598 => C01380 + C00014 + C19571  
+new_r_0006	"biphenyl-2,3-dioxygenase"	R05263	"biphenyl[e] + NADH[e] + H+[e] + O2[e] => (1S,2R)-3-phenylcyclohexa-3,5-diene-1,2-diol[e] + NAD+"	(DSC_08750 and DSC_08755 and DSC_09320)	EC1.14.12.18	C06588 + C00007 + C00004 + C00080 <=> C06589 + C00003
+new_r_0007	"cis-2,3-dihydrobiphenyl-2,3-diol dehydrogenase"	R05239	"cis-3-phenylcyclohexa-3,5-diene-1,2-diol[e] + NAD+[e] => biphenyl-2,3-diol[e] + NADH[e] + H+[e]"	 DSC_09350	EC1.3.1.56	C06589 + C00003 <=> C02526 + C00004 + C00080
+new_r_0008	"biphenyl-2,3-diol 1,2-dioxygenase"	R03462	"biphenyl-2,3-diol[e] + O2[e] => 2-hydroxy-6-oxo-6-phenylhexa-2,4-dienoate[e]"	DSC_09355	EC1.13.11.39	C02526 + C00007 <=> C01273
+new_r_0009	"2,6-dioxo-6-phenylhexa-3-enoate hydrolase"	R02606	"2,6-dioxo-6-phenylhexa-3-enoate[e] + H2O[e] => benzoate[e] + 2-oxopent-4-enoate[e]"	DSC_09385	EC3.7.1.8	C01273 + C00001 <=> C00180 + C00596

--- a/GEM/parameters/Michaelis_constant_prods.txt
+++ b/GEM/parameters/Michaelis_constant_prods.txt
@@ -1,0 +1,20 @@
+Michaelis constant	new_r_0001	(ethylene terephthalate)n-1	NaN	mM	[EC3.1.1.101]	closest
+Michaelis constant	new_r_0001	4-[(2-hydroxyethoxy)-carbonyl]benzoate	NaN	mM	[EC3.1.1.101]	closest
+Michaelis constant	new_r_0002	terephthalate	NaN	mM	[EC3.1.1.102]	closest
+Michaelis constant	new_r_0002	ethylene glycol	NaN	mM	[EC3.1.1.102]	closest
+Michaelis constant	new_r_0003	glycolaldehyde	NaN	mM	[EC1.1.1.77]	closest
+Michaelis constant	new_r_0003	nadh	NaN	mM	[EC1.1.1.77]	closest
+Michaelis constant	new_r_0003	h+	NaN	mM	[EC1.1.1.77]	closest
+Michaelis constant	new_r_0004	aldehyde	NaN	mM	[EC1.1.99.20]	closest
+Michaelis constant	new_r_0004	nadh	NaN	mM	[EC1.1.99.20]	closest
+Michaelis constant	new_r_0005	ehylene glycol	NaN	mM	[EC3.1.1.3]	closest
+Michaelis constant	new_r_0005	ammonia	NaN	mM	[EC3.1.1.3]	closest
+Michaelis constant	new_r_0005	polymethylene polyphenyl isocyanate	NaN	mM	[EC3.1.1.3]	closest
+Michaelis constant	new_r_0006	(1s,2r)-3-phenylcyclohexa-3,5-diene-1,2-diol	NaN	mM	[EC1.14.12.18]	closest
+Michaelis constant	new_r_0006	nad+	NaN	mM	[EC1.14.12.18]	closest
+Michaelis constant	new_r_0007	nadh	NaN	mM	[EC1.3.1.56]	closest
+Michaelis constant	new_r_0007	h+	NaN	mM	[EC1.3.1.56]	closest
+Michaelis constant	new_r_0007	biphenyl-2,3-diol	NaN	mM	[EC1.3.1.56]	closest
+Michaelis constant	new_r_0008	2-hydroxy-6-oxo-6-phenylhexa-2,4-dienoate	NaN	mM	[EC1.13.11.39]	closest
+Michaelis constant	new_r_0009	benzoate	NaN	mM	[EC3.7.1.8]	closest
+Michaelis constant	new_r_0009	2-oxopent-4-enoate	NaN	mM	[EC3.7.1.8]	closest

--- a/GEM/parameters/Michaelis_constant_subs.txt
+++ b/GEM/parameters/Michaelis_constant_subs.txt
@@ -1,0 +1,20 @@
+Michaelis constant	new_r_0001	(ethylene terephthalate)n	NaN	mM	[EC3.1.1.101]	closest
+Michaelis constant	new_r_0001	h2o	NaN	mM	[EC3.1.1.101]	closest
+Michaelis constant	new_r_0002	h2o	NaN	mM	[EC3.1.1.102]	closest
+Michaelis constant	new_r_0002	4-[(2-hydroxyethoxy)carbonyl]benzoate	NaN	mM	[EC3.1.1.102]	closest
+Michaelis constant	new_r_0003	ethylene glycol	NaN	mM	[EC1.1.1.77]	closest
+Michaelis constant	new_r_0003	nad+	NaN	mM	[EC1.1.1.77]	closest
+Michaelis constant	new_r_0004	primary alcohol	NaN	mM	[EC1.1.99.20]	closest
+Michaelis constant	new_r_0004	nad+	NaN	mM	[EC1.1.99.20]	closest
+Michaelis constant	new_r_0005	h2o	NaN	mM	[EC3.1.1.3]	closest
+Michaelis constant	new_r_0005	polyurethane	NaN	mM	[EC3.1.1.3]	closest
+Michaelis constant	new_r_0006	biphenyl	0.00018	mM	[EC1.14.12.18]	closest
+Michaelis constant	new_r_0006	nadh	NaN	mM	[EC1.14.12.18]	closest
+Michaelis constant	new_r_0006	h+	NaN	mM	[EC1.14.12.18]	closest
+Michaelis constant	new_r_0006	o2	NaN	mM	[EC1.14.12.18]	closest
+Michaelis constant	new_r_0007	cis-3-phenylcyclohexa-3,5-diene-1,2-diol	NaN	mM	[EC1.3.1.56]	closest
+Michaelis constant	new_r_0007	nad+	NaN	mM	[EC1.3.1.56]	closest
+Michaelis constant	new_r_0008	o2	0.028	mM	[EC1.13.11.39]	closest
+Michaelis constant	new_r_0008	biphenyl-2,3-diol	0.00046	mM	[EC1.13.11.39]	closest
+Michaelis constant	new_r_0009	h2o	NaN	mM	[EC3.7.1.8]	closest
+Michaelis constant	new_r_0009	2,6-dioxo-6-phenylhexa-3-enoate	0.00075	mM	[EC3.7.1.8]	closest

--- a/GEM/parameters/catalytic_rate_constant_prods.txt
+++ b/GEM/parameters/catalytic_rate_constant_prods.txt
@@ -1,0 +1,9 @@
+catalytic rate constant	new_r_0001		12.4	1/s	[EC3.1.1.101]	closest
+catalytic rate constant	new_r_0002		26.8	1/s	[EC3.1.1.102]	closest
+catalytic rate constant	new_r_0003		NaN	1/s	[EC1.1.1.77]	closest
+catalytic rate constant	new_r_0004		12	1/s	[EC1.1.99.20]	closest
+catalytic rate constant	new_r_0005		3000	1/s	[EC3.1.1.3]	closest
+catalytic rate constant	new_r_0006		4.6	1/s	[EC1.14.12.18]	closest
+catalytic rate constant	new_r_0007		0.9	1/s	[EC1.3.1.56]	closest
+catalytic rate constant	new_r_0008		115	1/s	[EC1.13.11.39]	closest
+catalytic rate constant	new_r_0009		12	1/s	[EC3.7.1.8]	escherichia coli

--- a/GEM/parameters/catalytic_rate_constant_subs.txt
+++ b/GEM/parameters/catalytic_rate_constant_subs.txt
@@ -1,0 +1,9 @@
+catalytic rate constant	new_r_0001		12.4	1/s	[EC3.1.1.101]	closest
+catalytic rate constant	new_r_0002		26.8	1/s	[EC3.1.1.102]	closest
+catalytic rate constant	new_r_0003		NaN	1/s	[EC1.1.1.77]	closest
+catalytic rate constant	new_r_0004		12	1/s	[EC1.1.99.20]	closest
+catalytic rate constant	new_r_0005		3000	1/s	[EC3.1.1.3]	closest
+catalytic rate constant	new_r_0006		4.6	1/s	[EC1.14.12.18]	closest
+catalytic rate constant	new_r_0007		0.9	1/s	[EC1.3.1.56]	closest
+catalytic rate constant	new_r_0008		115	1/s	[EC1.13.11.39]	closest
+catalytic rate constant	new_r_0009		12	1/s	[EC3.7.1.8]	escherichia coli

--- a/GEM/parameters/kEqTable.txt
+++ b/GEM/parameters/kEqTable.txt
@@ -1,0 +1,6 @@
+!!SBtab TableName=Parameter TableType=Quantity Document=S. cervisiae central carbon metabolism SBtabVersion=1.0
+!QuantityType	!Reaction	!Compound	!Value	!Unit	!Reaction:Identifiers:kegg.reaction	!Compound:Identifiers:kegg.compound	!ID
+equilibrium constant	new_r_0006	 	4.797174554640046e+52	dimensionless	R05263	 	kEQ_new_r_0006
+equilibrium constant	new_r_0007	 	3.270988623419444e+18	dimensionless	R05239	 	kEQ_new_r_0007
+equilibrium constant	new_r_0008	 	2.0278633000250036e+42	dimensionless	R03462	 	kEQ_new_r_0008
+equilibrium constant	new_r_0009	 	6191334934.398192	dimensionless	R02606	 	kEQ_new_r_0009

--- a/GEM/scripts/getPathwayData.m
+++ b/GEM/scripts/getPathwayData.m
@@ -1,0 +1,114 @@
+function path_data = getPathwayData(pathFile)
+%getPathwayData
+%
+% Get a file with description of a pathway in a reaction-formulas fashion
+% and create a structure with all substrates, products and EC numbers by
+% rxn. This structure is needed by the ECM pipeline in order to obtain
+% kinetic parameters for the given pathway (Kcats and KMs).
+%
+%   pathFile  string indicating the name of the text (tab-separated) file
+%             in which the pathway is defined. The file should be stored in
+%             root/GEM/Data
+%
+%   path_data structure with fields substrates, products and ECnumbers,
+%             which contain rows for each reaction in the model.
+%
+% Usage: path_data = getPathwayData
+%
+% Last modified: Ivan Domenzain 2020-07-25
+%
+
+%Open file with pathway description
+pathway_table = readtable(['../Data/' pathFile],'delimiter','\t');
+%initialize variables
+substrates = cell(height(pathway_table),20);
+products   = cell(height(pathway_table),20);
+EC_numbers = cell(height(pathway_table),20);
+S          = zeros(100,height(pathway_table));
+metNames   = [];
+mets       = [];
+rxns       = [];
+rxnNames   = [];
+grRules    = [];
+metCounts  = 1;
+%Explore pathway rxn by rxn
+for i=1:height(pathway_table)
+    formula  = pathway_table.rxnFormula{i};
+    rxns     = [rxns;pathway_table.rxnID(i)];
+    rxnNames = [rxnNames;pathway_table.rxnNames(i)];
+    grRules  = [grRules; pathway_table.grRules(i)];
+    if contains(formula,'<=>')
+        delim = '<=>';
+    else
+        delim = '=>';
+    end
+    %Split reactants and products
+    formula = strsplit(formula,delim);
+    rxnSubs  = formula{1};
+    rxnProds = formula{2};
+    rxnSubs  = strsplit(rxnSubs,' + ');
+    rxnProds = strsplit(rxnProds,' + ');
+    %Get all individual substrates for rxn
+    k=1;
+    for j=1:length(rxnSubs)
+        substrate = rxnSubs{j};
+        if length(substrate)>2
+            substrates{i,k} = substrate;
+            index = find(strcmpi(substrate,metNames));
+            if isempty(index)
+                metNames = [metNames; {substrate}];
+                mets = [mets; {['m_' sprintf( '%04d',metCounts)]}];
+                index    = metCounts;
+                metCounts = metCounts+1;
+            end
+            k = k+1;
+            S(index,i) = -1;
+        end
+    end
+    %Get all individual products for rxn
+    k=1;
+    for j=1:length(rxnProds)
+        product = rxnProds{j};
+        if length(product)>3
+            products{i,k} = product;
+            index = find(strcmpi(product,metNames));
+            if isempty(index)
+                metNames = [metNames; {product}];
+                mets = [mets; {['m_' sprintf( '%04d',metCounts)]}];
+                index     = metCounts;
+                metCounts = metCounts+1;
+            end
+            k = k+1;
+            S(index,i) = +1;
+        end
+    end
+    %Get ECnumbers
+    ECnum = pathway_table.Ecnumbers{i};
+    if ~isempty(ECnum)
+        ECnum = strsplit(ECnum,' ');
+        for j=1:length(ECnum)
+            EC_numbers{i,j} = ECnum{j};
+        end
+    end
+end
+path_data.substrates = substrates;
+path_data.products   = products;
+path_data.EC_numbers = EC_numbers;
+for i=1:length(metNames)
+    met = metNames{i};
+    idx = strfind(met,'[');
+    if ~isempty(idx)
+    	met = met(1:(idx(end)-1));
+        metNames{i} = met;
+    end
+end
+model = struct();
+S = S(1:length(metNames),:);
+model.metNames  = strtrim(metNames);
+model.mets      = mets;
+model.rxnNames  = strtrim(rxnNames);
+model.rxns      = strtrim(rxns);
+model.grRules   = strtrim(grRules);
+model.S         = S;
+path_data.model = model;
+end

--- a/GEM/scripts/getPathwayData.m
+++ b/GEM/scripts/getPathwayData.m
@@ -1,4 +1,4 @@
-function path_data = getPathwayData(pathFile)
+function [path_data, model,KEGGmodel] = getPathwayData(pathFile)
 %getPathwayData
 %
 % Get a file with description of a pathway in a reaction-formulas fashion
@@ -6,13 +6,17 @@ function path_data = getPathwayData(pathFile)
 % rxn. This structure is needed by the ECM pipeline in order to obtain
 % kinetic parameters for the given pathway (Kcats and KMs).
 %
-%   pathFile  string indicating the name of the text (tab-separated) file
+%   pathFile  (string) indicating the name of the text (tab-separated) file
 %             in which the pathway is defined. The file should be stored in
 %             root/GEM/Data
 %
-%   path_data structure with fields substrates, products and ECnumbers,
-%             which contain rows for each reaction in the model.
-%
+%   path_data (structure) with fields substrates, products and ECnumbers,
+%             which contain rows for each reaction in the pathway. 
+%   model     (structure) with a stoichiometric representation of the pathway 
+%             in a RAVEN format.
+%   KEGGmodel (table) Table with a KEGG format model for the provided
+%              pathway, compatible with the "ECM" and "equilibrator" pipelines
+% 
 % Usage: path_data = getPathwayData
 %
 % Last modified: Ivan Domenzain 2020-07-25
@@ -43,7 +47,7 @@ for i=1:height(pathway_table)
         delim = '=>';
     end
     %Split reactants and products
-    formula = strsplit(formula,delim);
+    formula  = strsplit(formula,delim);
     rxnSubs  = formula{1};
     rxnProds = formula{2};
     rxnSubs  = strsplit(rxnSubs,' + ');
@@ -110,5 +114,6 @@ model.rxnNames  = strtrim(rxnNames);
 model.rxns      = strtrim(rxns);
 model.grRules   = strtrim(grRules);
 model.S         = S;
-path_data.model = model;
+keggVariables   = {'ID','Name','ReactionFormula','KEGGIDs'};
+KEGGmodel       = table(strtrim(rxns),strtrim(rxnNames),pathway_table.KEGG_formula,pathway_table.KEGG_id,'VariableNames',keggVariables);
 end

--- a/GEM/scripts/parameterize_pathway.m
+++ b/GEM/scripts/parameterize_pathway.m
@@ -1,14 +1,28 @@
 %parameterize_pathway
-
+current = pwd;
 %clone ECM_yeast repository in the current directory
 system('git clone --depth 1 https://github.com/SysBioChalmers/ECM_yeast.git');
 system('git clone --depth 1 https://github.com/SysBioChalmers/GECKO.git');
 %Get pathway data
-path_data = getPathwayData('pathway_description.txt');
+[path_data,model,KEGGmodel] = getPathwayData('pathway_description.txt');
+path_data.model = model;
+writetable(KEGGmodel,'ECM_yeast/models/KEGG_model_Scaffold.txt','delimiter','\t');
 %parameterize pathway
-cd ECM_yeast/code/parameterize_model
+cd ECM_yeast
+ECMpath = pwd;
+cd code/parameterize_model
 system('git checkout fix/model_curation');
 %Get Kcats (forward and backward) for each reaction based on EC#
 [Ks, Kp] = getKineticData(path_data,'escherichia coli','catalytic rate constant');
 [Ks, Kp] = getKineticData(path_data,'escherichia coli','Michaelis constant');
+%Try to run equilibrator from MATLAB, if it doesn't work then run locally
+commandStr = ['python ' ECMpath '/code/parameterize_model/getKeq.py'];
+status = system(commandStr);
+if status~=0
+    disp('getKeq.py failed to execute from MATLAB, try to run it separately')
+    disp('in a terminal, once this is done, press any key to continue')
+    pause
+end
+movefile([ECMpath '/results/parameters'],'../../../../')
+
 

--- a/GEM/scripts/parameterize_pathway.m
+++ b/GEM/scripts/parameterize_pathway.m
@@ -1,0 +1,14 @@
+%parameterize_pathway
+
+%clone ECM_yeast repository in the current directory
+system('git clone --depth 1 https://github.com/SysBioChalmers/ECM_yeast.git');
+system('git clone --depth 1 https://github.com/SysBioChalmers/GECKO.git');
+%Get pathway data
+path_data = getPathwayData('pathway_description.txt');
+%parameterize pathway
+cd ECM_yeast/code/parameterize_model
+system('git checkout fix/model_curation');
+%Get Kcats (forward and backward) for each reaction based on EC#
+[Ks, Kp] = getKineticData(path_data,'escherichia coli','catalytic rate constant');
+[Ks, Kp] = getKineticData(path_data,'escherichia coli','Michaelis constant');
+


### PR DESCRIPTION
A pipeline for retrieving Kcats, Kms from BRENDA, using the [ECM method](https://github.com/SysBioChalmers/ECM_yeast), and Keq calculation (using the [equilibrator-API](https://gitlab.com/equilibrator/equilibrator-api)). 

Results are stored in .txt files [here](https://github.com/leticiacastillon/iGEMChalmers2020/tree/fix/solve_issues_ivan/GEM/parameters). In summary:
 - Almost complete coverage was achieved for forward Kcats.
- For most of the reactions the forward Kcat was assigned to the backward direction due to lack of data reported for the products of the given reactions.
- No Km's were found for the products of the given reactions and a couple of Kms were successfully retrieved for substrates. 
- KEQ's for 4 reactions were successfully calculated by the equilibrator pipeline.

This parameterization procedure is run by the script `parameterize_pathway.m` stored in `GEM/scripts`, which relies on some other complementary functions also present in the same folder.